### PR TITLE
ci: build arm binaries

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,12 +4,7 @@
 
 name: build
 
-on: 
-  push:
-    branches-ignore: continuous
-    tags-ignore: continuous
-  pull_request:
-    branches-ignore: continuous
+on: [push, pull_request]
 
 # This ensures that jobs get canceled when force-pushing
 concurrency:
@@ -29,16 +24,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [ x86, x86_64 ]
+        include:
+        - { qemu_arch: x86,     appimage_arch: x86 }
+        - { qemu_arch: x86_64,  appimage_arch: x86_64 }
+        - { qemu_arch: armv7,   appimage_arch: armhf }
+        - { qemu_arch: aarch64, appimage_arch: aarch64 }
 
     steps:
     - name: Checkout
       uses: actions/checkout@v3
 
     - name: Build
+      if: contains(matrix.qemu_arch, 'x86')
       env:
-        ARCHITECTURE: ${{ matrix.arch }}
-      run: ./build.sh
+        ARCHITECTURE: ${{ matrix.appimage_arch }}
+      run: ./chroot_build.sh
+
+    - name: Build (qemu)
+      if: ${{ !contains(matrix.qemu_arch, 'x86') }}
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: ${{ matrix.qemu_arch }}
+        distro: alpine_latest
+        env: |
+          ARCHITECTURE: ${{ matrix.appimage_arch }}
+        dockerRunArgs: |
+          --volume "${PWD}/out:/out"
+        run: ./build.sh
 
     - name: Upload to releases
       if: github.event_name != 'pull_request'

--- a/build.sh
+++ b/build.sh
@@ -2,71 +2,33 @@
 
 set -ex
 
-#############################################
-# Download and extract minimal Alpine system
-#############################################
+if ! command -v apk; then
+	echo "This script should be run in an Alpine container"
+	exit 1
+fi
 
-wget http://dl-cdn.alpinelinux.org/alpine/v3.10/releases/$ARCHITECTURE/alpine-minirootfs-3.10.2-$ARCHITECTURE.tar.gz
-sudo rm -rf ./miniroot  true # Clean up from previous runs
-mkdir -p ./miniroot
-cd ./miniroot
-sudo tar xf ../alpine-minirootfs-3.10.2-$ARCHITECTURE.tar.gz
-cd -
-
-#############################################
-# Build static patchelf
-# https://github.com/NixOS/patchelf/issues/185
-#############################################
-
-wget https://github.com/NixOS/patchelf/archive/0.9.tar.gz # 0.10 cripples my files, puts XXXXX inside
-tar xf 0.9.tar.gz
-cd patchelf-*/
-sudo apt install autoconf
-./bootstrap.sh
-./configure --prefix=/usr
-make -j$(nproc) LDFLAGS=-static
-file src/patchelf
-sudo cp src/patchelf ../miniroot/usr/bin/ # Make available inside the chroot too
-cd -
-
-#############################################
-# Prepare chroot
-#############################################
-
-sudo mount -o bind /dev miniroot/dev
-sudo mount -t proc none miniroot/proc
-sudo mount -t sysfs none miniroot/sys
-sudo cp -p /etc/resolv.conf miniroot/etc/
-sudo chroot miniroot /bin/sh -ex <<\EOF
-
-#############################################
-# Now inside chroot
-#############################################
-
-# Install build dependencies
 apk update
-apk add alpine-sdk bash util-linux strace file zlib-dev autoconf automake libtool
+apk add alpine-sdk util-linux strace file zlib-dev zlib-static autoconf automake libtool
 
 # Build static squashfs-tools
-wget -c http://deb.debian.org/debian/pool/main/s/squashfs-tools/squashfs-tools_4.4.orig.tar.gz
-tar xf squashfs-tools_4.4.orig.tar.gz
-cd squashfs-tools-4.4/squashfs-tools
-make -j$(nproc)
-gcc -static mksquashfs.o read_fs.o action.o swap.o pseudo.o compressor.o sort.o progressbar.o read_file.o info.o restore.o process_fragments.o caches-queues-lists.o gzip_wrapper.o xattr.o read_xattrs.o -lm -lz -o mksquashfs
-gcc -static unsquashfs.o unsquash-1.o unsquash-2.o unsquash-3.o unsquash-4.o unsquash-123.o unsquash-34.o swap.o compressor.o unsquashfs_info.o gzip_wrapper.o read_xattrs.o unsquashfs_xattr.o -lm -lz -o unsquashfs
+wget -O squashfs-tools.tar.gz https://github.com/plougher/squashfs-tools/archive/refs/tags/4.5.1.tar.gz
+tar xf squashfs-tools.tar.gz
+cd squashfs-tools-*/squashfs-tools
+make -j$(nproc) LDFLAGS=-static
+file mksquashfs unsquashfs
 strip mksquashfs unsquashfs
-cd ../../
+cd -
 
 # Build static desktop-file-utils
 apk add glib-static glib-dev
 wget -c https://www.freedesktop.org/software/desktop-file-utils/releases/desktop-file-utils-0.15.tar.gz
-tar xf desktop-file-utils-0.15.tar.gz
-cd desktop-file-utils-0.15
+tar xf desktop-file-utils-*.tar.gz
+cd desktop-file-utils-*/
 # The next 2 lines are a workaround for: checking build system type... ./config.guess: unable to guess system type
 wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD' -O config.guess
 wget 'http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD' -O config.sub
 autoreconf --install # https://github.com/shendurelab/LACHESIS/issues/31#issuecomment-283963819
-./configure
+./configure CFLAGS=-no-pie LDFLAGS=-static
 make -j$(nproc)
 cd src/
 gcc -static -o desktop-file-validate keyfileutils.o validate.o validator.o -lglib-2.0 -lintl
@@ -76,18 +38,18 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson cmake libxml2-dev yaml-dev gobject-introspection-dev snowball-dev gperf
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
-tar xf openldap-LMDB_0.9.29.tar.gz
-cd openldap-LMDB_0.9.29/libraries/liblmdb
+tar xf openldap-LMDB_*.tar.gz
+cd openldap-LMDB_*/libraries/liblmdb
 make liblmdb.a
-sudo install -D -m 644 liblmdb.a /usr/local/lib/liblmdb.a
-sudo install -D -m 644 lmdb.h /usr/local/include/lmdb.h
+install -D -m 644 liblmdb.a /usr/local/lib/liblmdb.a
+install -D -m 644 lmdb.h /usr/local/include/lmdb.h
 cd -
-wget -c https://github.com/ximion/appstream/archive/v0.12.9.tar.gz
-tar xf v0.12.9.tar.gz
-cd appstream-0.12.9
+wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v0.12.9.tar.gz
+tar xf appstream.tar.gz
+cd appstream-*/
 # Ask for static dependencies
 sed -i -E -e "s|(dependency\('.*')|\1, static: true|g" meson.build
 # Disable po, docs and tests
@@ -102,39 +64,21 @@ file prefix/bin/appstreamcli
 cd -
 
 # Build static bsdtar
-apk add zlib-dev bzip2-dev # What happened to zlib-static?
+apk add zlib-dev zlib-static bzip2-dev bzip2-static xz-dev
 wget https://www.libarchive.org/downloads/libarchive-3.3.2.tar.gz
-tar xf libarchive-3.3.2.tar.gz
-cd libarchive-3.3.2
-./configure LDFLAGS='--static' --enable-bsdtar=static --disable-shared --with-zlib --without-bz2lib
+tar xf libarchive-*.tar.gz
+cd libarchive-*/
+./configure --disable-shared --enable-bsdtar=static --disable-bsdcat --disable-bsdcpio --with-zlib --without-bz2lib --disable-maintainer-mode --disable-dependency-tracking CFLAGS=-no-pie LDFLAGS=-static
 make -j$(nproc)
-gcc -static -o bsdtar tar/bsdtar-bsdtar.o tar/bsdtar-cmdline.o tar/bsdtar-creation_set.o tar/bsdtar-read.o tar/bsdtar-subst.o tar/bsdtar-util.o tar/bsdtar-write.o .libs/libarchive.a .libs/libarchive_fe.a /lib/libz.a
+gcc -static -o bsdtar tar/bsdtar-bsdtar.o tar/bsdtar-cmdline.o tar/bsdtar-creation_set.o tar/bsdtar-read.o tar/bsdtar-subst.o tar/bsdtar-util.o tar/bsdtar-write.o .libs/libarchive.a .libs/libarchive_fe.a /lib/libz.a -llzma
 strip bsdtar
-cd ..
+cd -
 
-#############################################
-# Exit chroot and clean up
-#############################################
-
-exit
-EOF
-sudo umount miniroot/proc miniroot/sys miniroot/dev
-
-#############################################
-# Copy build artefacts out
-#############################################
-
-
-# Use the same architecture names as https://github.com/AppImage/AppImageKit/releases/
-if [ "$ARCHITECTURE" = "x86" ] ; then export ARCHITECTURE=i686 ; fi
-
-mkdir out/
-sudo find miniroot/ -type f -executable -name 'mksquashfs' -exec cp {} out/mksquashfs-$ARCHITECTURE \; 2>/dev/null
-sudo find miniroot/ -type f -executable -name 'unsquashfs' -exec cp {} out/unsquashfs-$ARCHITECTURE \; 2>/dev/null
-sudo find miniroot/ -type f -executable -name 'bsdtar' -exec cp {} out/bsdtar-$ARCHITECTURE \; 2>/dev/null
-sudo find miniroot/ -type f -executable -name 'desktop-file-install' -exec cp {} out/desktop-file-install-$ARCHITECTURE \; 2>/dev/null
-sudo find miniroot/ -type f -executable -name 'desktop-file-validate' -exec cp {} out/desktop-file-validate-$ARCHITECTURE \; 2>/dev/null
-sudo find miniroot/ -type f -executable -name 'update-desktop-database' -exec cp {} out/update-desktop-database-$ARCHITECTURE \; 2>/dev/null
-sudo cp miniroot/appstream-0.12.9/prefix/bin/appstreamcli out/appstreamcli-$ARCHITECTURE
-sudo find patchelf-*/ -type f -executable -name 'patchelf' -exec cp {} out/patchelf-$ARCHITECTURE \; 2>/dev/null
-sudo rm -rf miniroot/ patchelf-*/
+mkdir -p out
+cp squashfs-tools-*/squashfs-tools/mksquashfs out/mksquashfs-$ARCHITECTURE
+cp squashfs-tools-*/squashfs-tools/unsquashfs out/unsquashfs-$ARCHITECTURE
+cp libarchive-*/bsdtar out/bsdtar-$ARCHITECTURE
+cp desktop-file-utils-*/src/desktop-file-install out/desktop-file-install-$ARCHITECTURE
+cp desktop-file-utils-*/src/desktop-file-validate out/desktop-file-validate-$ARCHITECTURE
+cp desktop-file-utils-*/src/update-desktop-database out/update-desktop-database-$ARCHITECTURE
+cp appstream-*/prefix/bin/appstreamcli out/appstreamcli-$ARCHITECTURE

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+
+set -ex
+
+#############################################
+# Download and extract minimal Alpine system
+#############################################
+
+wget http://dl-cdn.alpinelinux.org/alpine/v3.15/releases/$ARCHITECTURE/alpine-minirootfs-3.15.4-$ARCHITECTURE.tar.gz
+sudo rm -rf ./miniroot  true # Clean up from previous runs
+mkdir -p ./miniroot
+cd ./miniroot
+sudo tar xf ../alpine-minirootfs-*-$ARCHITECTURE.tar.gz
+cd -
+
+#############################################
+# Prepare chroot
+#############################################
+
+sudo mount -o bind /dev miniroot/dev
+sudo mount -t proc none miniroot/proc
+sudo mount -t sysfs none miniroot/sys
+sudo cp -p /etc/resolv.conf miniroot/etc/
+sudo chroot miniroot /bin/sh -ex <build.sh
+sudo umount miniroot/proc miniroot/sys miniroot/dev
+
+#############################################
+# Copy build artefacts out
+#############################################
+
+
+# Use the same architecture names as https://github.com/AppImage/AppImageKit/releases/
+if [ "$ARCHITECTURE" = "x86" ] ; then ARCHITECTURE=i686 ; fi
+
+mkdir out/
+sudo find miniroot/ -type f -executable -name 'mksquashfs' -exec cp {} out/mksquashfs-$ARCHITECTURE \;
+sudo find miniroot/ -type f -executable -name 'unsquashfs' -exec cp {} out/unsquashfs-$ARCHITECTURE \;
+sudo find miniroot/ -type f -executable -name 'bsdtar' -exec cp {} out/bsdtar-$ARCHITECTURE \;
+sudo find miniroot/ -type f -executable -name 'desktop-file-install' -exec cp {} out/desktop-file-install-$ARCHITECTURE \;
+sudo find miniroot/ -type f -executable -name 'desktop-file-validate' -exec cp {} out/desktop-file-validate-$ARCHITECTURE \;
+sudo find miniroot/ -type f -executable -name 'update-desktop-database' -exec cp {} out/update-desktop-database-$ARCHITECTURE \;
+sudo cp miniroot/appstream-0.12.9/prefix/bin/appstreamcli out/appstreamcli-$ARCHITECTURE
+sudo rm -rf miniroot/


### PR DESCRIPTION
I have split build.sh in two parts. The first sets up and destroys the chroot, the other runs the actual builds command inside of the Alpine environment.

This makes it possible to run chroot_build.sh on CI's native architecture so that it handles creation of the native chroot, and run only build.sh in the run-on-arch action, that creates an Alpine container itelf.

Then I removed patchelf from the build because it seems that it was only used by the shared appstreamcli build. Please correct me if I'm wrong.

I also substituted version numbers with "*" when possible, so that updating versions of build binaries is easier (you'll only have to change the download URL)

As with #10 the release part is broken in my fork, but should be fine on your repo

Fixes #11