### PR TITLE
Automatically create a pre-release for each merge to master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,10 +39,11 @@ jobs:
 
     - name: Get git hash
       run: |
-           echo -n "https://github.com/${GITHUB_REPOSITORY}/commit/" > src/runtime/version
-           git rev-parse --short HEAD  | xargs >> src/runtime/version
+        VERSION="$(date --utc +%Y-%m-%d)-$(git rev-parse --short HEAD)"
+        echo -n "https://github.com/${GITHUB_REPOSITORY}/releases/tag/build-${VERSION}" > src/runtime/version
+        echo "${VERSION}" > tag.txt
 
-    - name: Build
+    - name: Build (x86)
       if: contains(matrix.qemu_arch, 'x86')
       env:
         ARCHITECTURE: ${{ matrix.appimage_arch }}
@@ -59,18 +60,17 @@ jobs:
         dockerRunArgs: |
           --volume "${PWD}/out:/out"
           --volume "${PWD}/src:/src"
-        run: |
-             ./build.sh
-             # echo "artifactName=$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
-    - uses: actions/upload-artifact@v3
+        run: ./build.sh
+
+    - name: Upload Build Artifacts
+      uses: actions/upload-artifact@v3
       with:
         name: artifacts
         path: ./out/*
 
-    - name: Upload to releases
+    - name: Create Release
       if: github.event_name != 'pull_request' && github.ref_name == 'master'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: out/*
-        tag_name: continuous
-
+      run: |
+        VERSION="$(cat tag.txt)"
+        gh release create --prerelease --title "Build ${VERSION}" "build-${VERSION}" out/* \
+          || gh release upload "build-${VERSION}" out/*


### PR DESCRIPTION
This PR changes the Github Actions CI to automatically create a pre-release commit with all artifacts, for every push to master.

It does this by using the `gh` cli instead of the `softprops/action-gh-release@v1` from the Marketplace. See https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows and https://cli.github.com/manual/gh_release for more info on that.

This will also change the version information used in the runtime to point to that release.
The date of the version information is queried once and stored to a file instead of being regenerated. In theory this helps avoid a date rollover problem, in practice there are still multiple GH Actions runners so it won't actually help much in this case.
I guess one could take the date of the commit instead of the date of the build. However the commit date may be anything and doesn't even have to be anywhere close to the build time. It's certainly nicer to have monotonically increasing build tags, so the build time is still a better choice IMO.

Providing many releases / a continuous deployment is better than a single, changing release on a `continuous` tag because it allows consumers of the release to depend on (the artifacts of) a specific version and ensure artifact integrity using file hashes. This is very important for Bazel builds, which put a focus on reproducibility and determinism.

I tested the change by forking the repo, and commenting out the line that restricts releases to only master pushes (so it would release for every PR commit as well).

The release itself looks something like this: https://github.com/lalten/static-tools/releases/tag/build-2022-09-23-2a69ce3