### PR TITLE
Remove Docker

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -43,25 +43,12 @@ jobs:
            git rev-parse --short HEAD  | xargs >> src/runtime/version
 
     - name: Build
-      if: contains(matrix.qemu_arch, 'x86')
       env:
         ARCHITECTURE: ${{ matrix.appimage_arch }}
-      run: ./chroot_build.sh
+      run: |
+           sudo apt-get -y install qemu-user-static
+           ./chroot_build.sh
 
-    - name: Build (qemu)
-      if: ${{ !contains(matrix.qemu_arch, 'x86') }}
-      uses: uraimo/run-on-arch-action@v2
-      with:
-        arch: ${{ matrix.qemu_arch }}
-        distro: alpine_latest
-        env: |
-          ARCHITECTURE: ${{ matrix.appimage_arch }}
-        dockerRunArgs: |
-          --volume "${PWD}/out:/out"
-          --volume "${PWD}/src:/src"
-        run: |
-             ./build.sh
-             # echo "artifactName=$GITHUB_RUN_NUMBER_$(date +%Y-%m-%d)-$(git rev-parse --short HEAD)" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v3
       with:
         name: artifacts
@@ -73,3 +60,4 @@ jobs:
       with:
         files: out/*
         tag_name: continuous
+        

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -6,11 +6,11 @@ set -ex
 # Download and extract minimal Alpine system
 #############################################
 
-wget http://dl-cdn.alpinelinux.org/alpine/v3.15/releases/$ARCHITECTURE/alpine-minirootfs-3.15.4-$ARCHITECTURE.tar.gz
+wget "http://dl-cdn.alpinelinux.org/alpine/v3.15/releases/${ARCHITECTURE}/alpine-minirootfs-3.15.4-${ARCHITECTURE}.tar.gz"
 sudo rm -rf ./miniroot  true # Clean up from previous runs
 mkdir -p ./miniroot
 cd ./miniroot
-sudo tar xf ../alpine-minirootfs-*-$ARCHITECTURE.tar.gz
+sudo tar xf ../alpine-minirootfs-*-"${ARCHITECTURE}".tar.gz
 cd -
 
 #############################################
@@ -28,7 +28,21 @@ sudo cp -p /etc/resolv.conf miniroot/etc/
 # Run build.sh in chroot
 #############################################
 
-sudo chroot miniroot /bin/sh -ex <build.sh
+if [ "$ARCHITECTURE" = "x86" ] || [ "$ARCHITECTURE" = "x86_64" ]; then
+    echo "Architecture is x86 or x86_64, hence not using qemu-arm-static"
+    sudo cp build.sh miniroot/build.sh && sudo chroot miniroot /bin/sh -ex /build.sh
+elif [ "$ARCHITECTURE" = "aarch64" ] ; then
+    echo "Architecture is aarch64, hence using qemu-aarch64-static"
+    sudo cp "$(which qemu-aarch64-static)" miniroot/usr/bin
+    sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-aarch64-static /bin/sh -ex /build.sh
+elif [ "$ARCHITECTURE" = "armhf" ] ; then
+    echo "Architecture is armhf, hence using qemu-arm-static"
+    sudo cp "$(which qemu-arm-static)" miniroot/usr/bin
+    sudo cp build.sh miniroot/build.sh && sudo chroot miniroot qemu-arm-static /bin/sh -ex /build.sh
+else
+    echo "Edit chroot_build.sh to support this architecture as well, it should be easy"
+    exit 1
+fi
 
 #############################################
 # Clean up chroot


### PR DESCRIPTION
Remove the need for uraimo/run-on-arch-action

Advantages:
* We can now pin all ingredients including Alpine Linux for all architectures
* Less complex
* Fewer external dependencies
* No more Docker needed
* All architectures now build in the same way
* Build speed did not suffer