### PR TITLE
AppStream 1.0

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -96,7 +96,7 @@ cd libxmlb-*
 meson build --default-library=static -Dintrospection=false -Dgtkdoc=false -Dcli=false
 ninja -C build
 ninja -C build install
-ldconfig
+# ldconfig # segfaults
 cd -
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -88,21 +88,12 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-# https://github.com/Artox/alpine-systemd
-apk add alpine-sdk git findutils shadow
-mkdir -p /var/cache/distfiles
-abuild-keygen -a -i -n
-git clone https://github.com/Artox/alpine-systemd.git
-cd alpine-systemd
-abuild -r
-find ~/packages/user -name 'libsystemd-dev-*.apk' -type f -exec apk add --allow-untrusted {} +
-# End of alpine-systemd
 apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz
 cd appstream-*/
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Ddefault_library=static
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false -Ddefault_library=static
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,7 @@ cd ../..
 # https://github.com/Artox/alpine-systemd
 apk add alpine-sdk git findutils shadow
 mkdir -p /var/cache/distfiles
-abuild-keygen -a -i
+abuild-keygen -a -i -n
 git clone https://github.com/Artox/alpine-systemd.git
 cd alpine-systemd
 abuild -r

--- a/build.sh
+++ b/build.sh
@@ -89,8 +89,8 @@ cd ../..
 
 # Build appstreamcli
 # https://github.com/Artox/alpine-systemd
-apk add alpine-sdk git findutils
-adduser -G abuild abuild
+apk add alpine-sdk git findutils shadow
+useradd -m -g abuild abuild # adduser -G abuild abuild
 mkdir -p /var/cache/distfiles
 chown abuild:abuild /var/cache/distfiles
 su - abuild

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,17 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-trap 'cat /appstream-1.0.2/build/meson-logs/meson-log.txt' EXIT
+# https://github.com/Artox/alpine-systemd
+apk add alpine-sdk git findutils
+adduser -G abuild abuild
+mkdir -p /var/cache/distfiles
+chown abuild:abuild /var/cache/distfiles
+su - abuild
+abuild-keygen -a -i
+git clone https://github.com/Artox/alpine-systemd.git
+cd alpine-systemd
+abuild -r
+find ~/packages/user -name 'libsystemd-dev-*.apk' -type f -exec apk add --allow-untrusted {} +
 apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-static curl-dev
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
 tar xf openldap-LMDB_*.tar.gz
@@ -107,7 +107,7 @@ sed -i -e "s|subdir('po/')||" meson.build
 sed -i -e "s|subdir('docs/')||" meson.build
 sed -i -e "s|subdir('tests/')||" meson.build
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --without-curl --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -94,7 +94,7 @@ wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.
 tar xf appstream.tar.gz
 cd appstream-*/
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Ddefault_library=static
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Ddefault_library=static
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
 tar xf openldap-LMDB_*.tar.gz
@@ -107,7 +107,7 @@ sed -i -e "s|subdir('po/')||" meson.build
 sed -i -e "s|subdir('docs/')||" meson.build
 sed -i -e "s|subdir('tests/')||" meson.build
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --without-curl --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
 tar xf openldap-LMDB_*.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,16 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev itstool
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl itstool # libxmlb-dev
+# libxmlb-static is missing, need to build our own
+wget https://github.com/hughsie/libxmlb/releases/download/0.3.15/libxmlb-0.3.15.tar.xz
+tar xf libxmlb-0.3.15.tar.xz
+cd libxmlb-*
+meson build --default-library=static
+ninja -C build
+ninja -C build install
+ldconfig
+cd -
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz
 cd appstream-*/

--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.
 tar xf appstream.tar.gz
 cd appstream-*/
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false -Ddefault_library=static
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false -default_library=static
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -90,25 +90,11 @@ cd ../..
 # Build appstreamcli
 trap 'cat /appstream-1.0.2/build/meson-logs/meson-log.txt' EXIT
 apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
-# Compile liblmdb from source as Alpine only ship it as a .so
-wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
-tar xf openldap-LMDB_*.tar.gz
-cd openldap-LMDB_*/libraries/liblmdb
-make liblmdb.a
-install -D -m 644 liblmdb.a /usr/local/lib/liblmdb.a
-install -D -m 644 lmdb.h /usr/local/include/lmdb.h
-cd -
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz
 cd appstream-*/
-# Ask for static dependencies
-sed -i -E -e "s|(dependency\('.*')|\1, static: true|g" meson.build
-# Disable po, docs and tests
-sed -i -e "s|subdir('po/')||" meson.build
-sed -i -e "s|subdir('docs/')||" meson.build
-sed -i -e "s|subdir('tests/')||" meson.build
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Ddefault_library=static
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-static
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-static curl-dev
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
 tar xf openldap-LMDB_*.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl itstool # libxmlb-dev
+apk add glib-static meson libxml2-dev libxml2-static yaml-dev yaml-static gperf curl-dev curl-static curl itstool # libxmlb-dev
 # libxmlb-static is missing, need to build our own
 wget https://github.com/hughsie/libxmlb/releases/download/0.3.15/libxmlb-0.3.15.tar.xz
 tar xf libxmlb-0.3.15.tar.xz

--- a/build.sh
+++ b/build.sh
@@ -93,7 +93,7 @@ apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-s
 wget https://github.com/hughsie/libxmlb/releases/download/0.3.15/libxmlb-0.3.15.tar.xz
 tar xf libxmlb-0.3.15.tar.xz
 cd libxmlb-*
-meson build --default-library=static
+meson build --default-library=static -Dintrospection=false -Dgtkdoc=false -Dcli=false
 ninja -C build
 ninja -C build install
 ldconfig

--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.
 tar xf appstream.tar.gz
 cd appstream-*/
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false -default-library=static
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --default-library=static --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/build.sh
+++ b/build.sh
@@ -90,15 +90,13 @@ cd ../..
 # Build appstreamcli
 # https://github.com/Artox/alpine-systemd
 apk add alpine-sdk git findutils shadow
-useradd -m -g abuild abuild # adduser -G abuild abuild
 mkdir -p /var/cache/distfiles
-chown abuild:abuild /var/cache/distfiles
-su - abuild
 abuild-keygen -a -i
 git clone https://github.com/Artox/alpine-systemd.git
 cd alpine-systemd
 abuild -r
 find ~/packages/user -name 'libsystemd-dev-*.apk' -type f -exec apk add --allow-untrusted {} +
+# End of alpine-systemd
 apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev itstool
 wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz
 cd appstream-*/

--- a/build.sh
+++ b/build.sh
@@ -97,7 +97,7 @@ make liblmdb.a
 install -D -m 644 liblmdb.a /usr/local/lib/liblmdb.a
 install -D -m 644 lmdb.h /usr/local/include/lmdb.h
 cd -
-wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v0.12.9.tar.gz
+wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.gz # Keep at v1.0.x so as to not have a moving target
 tar xf appstream.tar.gz
 cd appstream-*/
 # Ask for static dependencies

--- a/build.sh
+++ b/build.sh
@@ -88,6 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
+trap 'cat /appstream-1.0.2/build/meson-logs/meson-log.txt' EXIT
 apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-dev curl-static curl libxmlb-dev
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -88,7 +88,7 @@ strip desktop-file-install desktop-file-validate update-desktop-database
 cd ../..
 
 # Build appstreamcli
-apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf
+apk add glib-static meson libxml2-dev yaml-dev yaml-static gperf curl-static
 # Compile liblmdb from source as Alpine only ship it as a .so
 wget https://git.openldap.org/openldap/openldap/-/archive/LMDB_0.9.29/openldap-LMDB_0.9.29.tar.gz
 tar xf openldap-LMDB_*.tar.gz

--- a/build.sh
+++ b/build.sh
@@ -102,7 +102,7 @@ wget -O appstream.tar.gz https://github.com/ximion/appstream/archive/v1.0.2.tar.
 tar xf appstream.tar.gz
 cd appstream-*/
 # -no-pie is required to statically link to libc
-CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false -default_library=static
+CFLAGS=-no-pie LDFLAGS=-static meson setup build --buildtype=release --prefix="$(pwd)/prefix" --strip -Db_lto=true -Db_ndebug=if-release -Dstemming=false -Dgir=false -Dapidocs=false -Dinstall-docs=false -Dsystemd=false -default-library=static
 # Install in a staging enviroment
 meson install -C build
 file prefix/bin/appstreamcli

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -67,5 +67,5 @@ sudo find miniroot/ -type f -executable -name 'bsdtar' -exec cp {} out/bsdtar-$A
 sudo find miniroot/ -type f -executable -name 'desktop-file-install' -exec cp {} out/desktop-file-install-$ARCHITECTURE \;
 sudo find miniroot/ -type f -executable -name 'desktop-file-validate' -exec cp {} out/desktop-file-validate-$ARCHITECTURE \;
 sudo find miniroot/ -type f -executable -name 'update-desktop-database' -exec cp {} out/update-desktop-database-$ARCHITECTURE \;
-sudo cp miniroot/appstream-0.12.9/prefix/bin/appstreamcli out/appstreamcli-$ARCHITECTURE
+sudo cp miniroot/appstream-*/prefix/bin/appstreamcli out/appstreamcli-$ARCHITECTURE
 sudo rm -rf miniroot/

--- a/chroot_build.sh
+++ b/chroot_build.sh
@@ -6,7 +6,7 @@ set -ex
 # Download and extract minimal Alpine system
 #############################################
 
-wget "http://dl-cdn.alpinelinux.org/alpine/v3.15/releases/${ARCHITECTURE}/alpine-minirootfs-3.15.4-${ARCHITECTURE}.tar.gz"
+wget "http://dl-cdn.alpinelinux.org/alpine/v3.19/releases/${ARCHITECTURE}/alpine-minirootfs-3.19.1-${ARCHITECTURE}.tar.gz"
 sudo rm -rf ./miniroot  true # Clean up from previous runs
 mkdir -p ./miniroot
 cd ./miniroot


### PR DESCRIPTION
This PR shall build AppStream v1.0.x instead of what we have been using so far.

https://github.com/probonopd/go-appimage/issues/272

**Note to self:** If this doesn't work, a possibly less painful alternative might be https://github.com/probonopd/appstreamlint