### PR TITLE
Use a unique artifact name for each build in the matrix

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,7 +52,7 @@ jobs:
 
     - uses: actions/upload-artifact@v4
       with:
-        name: artifacts
+        name: ${{ matrix.appimage_arch }}
         path: ./out/*
 
     - name: Upload to releases


### PR DESCRIPTION
This works around a breaking change introduced in actions/upload-artifact@v4. This is the build failure we saw in #51.

See actions/upload-artifact#478